### PR TITLE
Fixed main window not being focused when splash closes

### DIFF
--- a/MainWindow.glade
+++ b/MainWindow.glade
@@ -60,7 +60,7 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
   </object>
   <object class="GtkWindow" id="MainWindow">
     <property name="can_focus">False</property>
-    <property name="window_position">center</property>
+    <property name="window_position">center-always</property>
     <property name="default_width">700</property>
     <property name="default_height">400</property>
     <property name="gravity">center</property>

--- a/SplashScreen.glade
+++ b/SplashScreen.glade
@@ -5,8 +5,7 @@
   <object class="GtkWindow" id="SplashScreenWindow">
     <property name="can_focus">False</property>
     <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
+    <property name="window_position">center-always</property>
     <property name="gravity">center</property>
     <signal name="delete-event" handler="on_SplashScreenWindow_delete_event" swapped="no"/>
     <child>


### PR DESCRIPTION
Currently when starting the app, the splash screen starts focused, then opens the main window and closes itself. The main window is not left focused, but the previously opened window (ie, whatever was in focus before you started the app) is.

This fixes that behaviour.