### PR TITLE
Enable remote node configuration for walletd

### DIFF
--- a/MainWindow.py
+++ b/MainWindow.py
@@ -412,7 +412,9 @@ class MainWindow(object):
 
         # Update the status label in the bottom right with block height, peer count, and last refresh time
         block_height_string = "<b>Current block height</b> {}".format(status['blockCount'])
-        if status['blockCount'] < status['knownBlockCount']:
+        # Buffer the block count by 1 due to latency issues
+        # Using a remote daemon for example will almost always be behind one block.
+        if status['blockCount']+1 < status['knownBlockCount']:
             block_height_string = "<b>Synchronizing with network...</b> [{} / {}]".format(status['blockCount'], status['knownBlockCount'])
         status_label = "{0} | <b>Peer count</b> {1} | <b>Last Updated</b> {2}".format(block_height_string, status['peerCount'], datetime.now(tzlocal.get_localzone()).strftime("%H:%M:%S"))
         self.builder.get_object("MainStatusLabel").set_markup(status_label)

--- a/SplashScreen.py
+++ b/SplashScreen.py
@@ -83,7 +83,8 @@ class SplashScreen(object):
                     GLib.idle_add(self.update_status, "Syncing... [{} / {}]".format(block_count, known_block_count))
                     splash_logger.debug("Syncing... [{} / {}]".format(block_count, known_block_count))
                     # Even though we check known block count, leaving it in there in case of weird edge cases
-                    if (known_block_count > 0) and (block_count >= known_block_count):
+                    # Buffer the block count by 1 due to latency issues, remote node will almost always be ahead by one
+                    if (known_block_count > 0) and (block_count+1 >= known_block_count):
                         GLib.idle_add(self.update_status, "Wallet is synced, opening...")
                         splash_logger.info("Wallet successfully synced, opening wallet")
                         break


### PR DESCRIPTION
If one so chooses to use a remote daemon, just add the following keys to the trtlconfig.json (if you don't see this file, it gets generated on first run I think):
```
{
...
"remoteDaemonAddress": "daemon.turtle.link",
"remoteDaemonPort": 11898
}
```

The next stage is probably a settings UI screen where the GUI could allow user input to set such values.

Side note, had to add blockCount+1 buffer due to latency issues between wallet and remote daemon (was almost always one block behind).
