### PR TITLE
UI improvements

### DIFF
--- a/MainWindow.glade
+++ b/MainWindow.glade
@@ -1043,7 +1043,6 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="margin_right">5</property>
-                <property name="label" translatable="yes">Loading...</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/MainWindow.glade
+++ b/MainWindow.glade
@@ -46,6 +46,8 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
   </object>
   <object class="GtkListStore" id="HomeTransactionsListStore">
     <columns>
+      <!-- column-name Hash -->
+      <column type="gchararray"/>
       <!-- column-name Direction -->
       <column type="gchararray"/>
       <!-- column-name Confirmed -->
@@ -404,13 +406,26 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                       <object class="GtkTreeSelection" id="treeview-selection1"/>
                     </child>
                     <child>
+                      <object class="GtkTreeViewColumn" id="HashColumn">
+                        <property name="visible">False</property>
+                        <property name="sizing">fixed</property>
+                        <property name="title" translatable="yes">Hash</property>
+                        <child>
+                          <object class="GtkCellRendererText" id="HashCellRenderer"/>
+                          <attributes>
+                            <attribute name="text">0</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkTreeViewColumn" id="DirectionColumn">
                         <property name="sizing">fixed</property>
                         <property name="title" translatable="yes">Direction</property>
                         <child>
                           <object class="GtkCellRendererText" id="DirectionCellRenderer"/>
                           <attributes>
-                            <attribute name="text">0</attribute>
+                            <attribute name="text">1</attribute>
                           </attributes>
                         </child>
                       </object>
@@ -421,7 +436,7 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                         <child>
                           <object class="GtkCellRendererToggle" id="ConfirmedCellRenderer"/>
                           <attributes>
-                            <attribute name="active">1</attribute>
+                            <attribute name="active">2</attribute>
                           </attributes>
                         </child>
                       </object>
@@ -432,7 +447,7 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                         <child>
                           <object class="GtkCellRendererText" id="AmountCellRenderer"/>
                           <attributes>
-                            <attribute name="text">2</attribute>
+                            <attribute name="text">3</attribute>
                           </attributes>
                         </child>
                       </object>
@@ -444,7 +459,7 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                         <child>
                           <object class="GtkCellRendererText" id="DateCellRenderer"/>
                           <attributes>
-                            <attribute name="text">3</attribute>
+                            <attribute name="text">4</attribute>
                           </attributes>
                         </child>
                       </object>
@@ -457,7 +472,7 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                         <child>
                           <object class="GtkCellRendererText" id="AddressCellRenderer"/>
                           <attributes>
-                            <attribute name="text">4</attribute>
+                            <attribute name="text">5</attribute>
                           </attributes>
                         </child>
                       </object>

--- a/MainWindow.glade
+++ b/MainWindow.glade
@@ -246,7 +246,7 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">end</property>
-                            <property name="label" translatable="yes">-1</property>
+                            <property name="label" translatable="yes">0</property>
                             <attributes>
                               <attribute name="scale" value="2"/>
                             </attributes>
@@ -319,7 +319,7 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">end</property>
-                            <property name="label" translatable="yes">-1</property>
+                            <property name="label" translatable="yes">0</property>
                             <attributes>
                               <attribute name="scale" value="2"/>
                             </attributes>
@@ -1043,7 +1043,7 @@ See the &lt;a href="http://www.gnu.org/licenses/lgpl-3.0.html"&gt;GNU Lesser Gen
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="margin_right">5</property>
-                <property name="label" translatable="yes">Status</property>
+                <property name="label" translatable="yes">Loading...</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -24,7 +24,7 @@ class UILogHandler(logging.Handler):
     """
     This class is a custom Logging.Handler that fires off every time
     a message is added to the applications log. This shows similar to
-    what the log file does, but the verbose is set to INFO instead of 
+    what the log file does, but the verbose is set to INFO instead of
     debug to keep logs in UI slim, and logs in the file more beefy.
     """
     def __init__(self, textbuffer):
@@ -50,7 +50,7 @@ class MainWindow(object):
         """Called by GTK when the copy button is clicked"""
         self.builder.get_object("AddressTextBox")
         Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD).set_text(self.builder.get_object("AddressTextBox").get_text(), -1)
-        
+
     def on_FeeSuggestionCheck_clicked(self, object, data=None):
         """Called by GTK when the FeeSuggestionCheck Checkbox is Toggled"""
         fee_entry = self.builder.get_object("FeeEntry")
@@ -61,7 +61,7 @@ class MainWindow(object):
         else:
             #enable fee entry
             fee_entry.set_sensitive(True)
-            
+
     def on_LogsMenuItem_activate(self, object, data=None):
         """Called by GTK when the LogsMenuItem Menu Item is Clicked
             This shows the log page on the main window"""
@@ -100,7 +100,7 @@ class MainWindow(object):
         """ Called by GTK when the RPCSend button has been clicked """
         method = self.builder.get_object("RPCMethodEntry").get_text()
         args = self.builder.get_object("RPCArgumentsEntry").get_text()
-        
+
         #Check the method and arg are somewhat valid
         if method == "":
             end_iter = self.RPCbuffer.get_end_iter()
@@ -112,7 +112,7 @@ class MainWindow(object):
             end_iter = self.RPCbuffer.get_end_iter()
             self.RPCbuffer.insert(end_iter, "\n\n" + 'ERROR: Invalid JSON in arguments given. Ex. \n {"blockCount":1000, "firstBlockIndex":1,"addresses":[ "22p4wUHAMndSscvtYErtqUaYrcUTvrZ9zhWwxc3JtkBHAnw4FJqenZyaePSApKWwJ5BjCJz1fKJoA6QHn5j6bVHg8A8dyhp"]}')
             return
-        
+
         #Send the request to RPC server and print results on textview
         try:
             r = global_variables.wallet_connection.request(method,args_dict)
@@ -121,17 +121,17 @@ class MainWindow(object):
         except Exception as e:
             end_iter = self.RPCbuffer.get_end_iter()
             self.RPCbuffer.insert(end_iter, "\n\n" + "ERROR:\n" + str(e))
-            
+
     def on_RPCTextView_size_allocate(self, *args):
         """The GTK Auto Scrolling method used to scroll RPC view when info is added"""
         adj = self.RPCScroller.get_vadjustment()
         adj.set_value(adj.get_upper() - adj.get_page_size())
-        
+
     def on_LogTextView_size_allocate(self, *args):
         """The GTK Auto Scrolling method used to scroll Log view when info is added"""
         adj = self.LogScroller.get_vadjustment()
         adj.set_value(adj.get_upper() - adj.get_page_size())
-        
+
 
     def on_AboutMenuItem_activate(self, object, data=None):
         """Called by GTK when the 'About' menu item is clicked"""
@@ -230,7 +230,7 @@ class MainWindow(object):
             self.builder.get_object("TransactionStatusLabel")\
                 .set_label("Slow down TRTL bro! The amount needs to be a number greater than 0.")
             return
-            
+
         #Determine Fee Settings
         #Get feeSuggest Checkbox widget
         feeSuggest = self.builder.get_object("FeeSuggestionCheck")
@@ -250,7 +250,7 @@ class MainWindow(object):
                 return
         else:
             fee = global_variables.static_fee
-            
+
         # Mixin
         mixin = int(self.builder.get_object("MixinSpinButton").get_text())
         body = {
@@ -395,7 +395,7 @@ class MainWindow(object):
                         desired_transfer_amount = (transaction['amount'] + transaction['fee']) * -1
                     else:
                         desired_transfer_amount = transaction['amount']
-                    
+
                     # Now loop through the transfers and find the address with the correctly transferred amount
                     for transfer in transaction['transfers']:
                         if transfer['amount'] == desired_transfer_amount:
@@ -457,7 +457,7 @@ class MainWindow(object):
         # Initialise the GTK builder and load the glade layout from the file
         self.builder = Gtk.Builder()
         self.builder.add_from_file("MainWindow.glade")
-        
+
         # Init. counters needed for watchdog function
         self.watchdogTimeout = 3
         self.watchdogMaxTry = 3
@@ -484,18 +484,18 @@ class MainWindow(object):
 
         # Setup the transaction spin button
         self.setup_spin_button()
-        
+
         # Setup UILogHandler so the Log Textview gets the same
         # information as the log file, with less verbose (INFO).
         uiHandler = UILogHandler(self.builder.get_object("LogBuffer"))
         uiHandler.setLevel(logging.INFO)
         main_logger.addHandler(uiHandler)
         self.LogScroller = self.builder.get_object("LogScrolledWindow")
-        
+
         #Setup UI RPC variables
         self.RPCbuffer = self.builder.get_object("RPCTextView").get_buffer()
         self.RPCScroller = self.builder.get_object("RPCScrolledWindow")
-        
+
         #Set the default fee amount in the FeeEntry widget
         self.builder.get_object("FeeEntry").set_text(str(float(global_variables.static_fee) / float(100)))
 
@@ -537,8 +537,8 @@ class MainWindow(object):
 
         # Finally, show the window
         self.window.show_all()
-        
-  
+
+
 
     def setup_spin_button(self):
         """
@@ -552,4 +552,3 @@ class MainWindow(object):
         adjustment = Gtk.Adjustment(0, 0, 31, 1, 1, 1)
         spin_button = self.builder.get_object("MixinSpinButton")
         spin_button.configure(adjustment, 1, 0)
-

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -424,13 +424,13 @@ class MainWindow(object):
 
         # Remove any transactions that are no longer valid
         # e.g. in case the daemon has accidentally forked and listed some transactions that are invalid
-        if self.blocks:
-            valid_transactions = [transaction['transactionHash'] for transaction in block['transactions'] for block in self.blocks]
-            for index, row in enumerate(self.transactions_list_store):
-                if row[0] not in valid_transactions:
-                    self.transactions_list_store.remove(row.iter)
-        else:
-            self.transactions_list_store.clear()
+        valid_transactions = []
+        for block in self.blocks:
+            for transaction in block['transactions']:
+                valid_transactions.append(transaction['transactionHash'])
+        for transaction in self.transactions_list_store:
+            if transaction[0] not in valid_transactions:
+                self.transactions_list_store.remove(transaction.iter)
 
         # Update the status label in the bottom right with block height, peer count, and last refresh time
         if self.status:

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -373,6 +373,7 @@ class MainWindow(object):
 
         # Iterate through the blocks and extract the relevant data
         # This is reversed to show most recent transactions first
+        tx_hash_list = [tx[0] for tx in self.transactions_list_store]
         for block in reversed(blocks):
             if block['transactions']: # Check the block contains any transactions
                 for transaction in block['transactions']: # Loop through each transaction in the block
@@ -392,7 +393,7 @@ class MainWindow(object):
                             break
 
                     # Append new transactions to the treeview's backing list store in the correct format
-                    if transaction['transactionHash'] not in [tx[0] for tx in self.transactions_list_store]:
+                    if transaction['transactionHash'] not in tx_hash_list:
                         self.transactions_list_store.append([
                             transaction['transactionHash'],
                             # Determine the direction of the transfer (In/Out)
@@ -407,6 +408,7 @@ class MainWindow(object):
                             # The address as located earlier
                             address
                         ])
+                        tx_hash_list = [tx[0] for tx in self.transactions_list_store]
 
         # Remove any transactions that are no longer valid
         # e.g. in case the daemon has accidentally forked and listed some transactions that are invalid

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -423,13 +423,16 @@ class MainWindow(object):
 
         # Remove any transactions that are no longer valid
         # e.g. in case the daemon has accidentally forked and listed some transactions that are invalid
-        valid_transactions = [transaction['transactionHash'] for transaction in block['transactions'] for block in self.blocks]
-        rows = self.transactions_list_store.iter_children(None)
-        while rows:
-            columns = self.transactions_list_store.iter_children(rows)
-            if columns and self.transactions_list_store.get_value(columns, 0) not in valid_transactions:
-                self.transactions_list_store.remove(columns)
-            rows = self.transactions_list_store.iter_next(rows)
+        if self.blocks:
+            valid_transactions = [transaction['transactionHash'] for transaction in block['transactions'] for block in self.blocks]
+            rows = self.transactions_list_store.iter_children(None)
+            while rows:
+                columns = self.transactions_list_store.iter_children(rows)
+                if columns and self.transactions_list_store.get_value(columns, 0) not in valid_transactions:
+                    self.transactions_list_store.remove(columns)
+                rows = self.transactions_list_store.iter_next(rows)
+        else:
+            self.transactions_list_store.clear()
 
         # Update the status label in the bottom right with block height, peer count, and last refresh time
         if self.status:
@@ -441,12 +444,12 @@ class MainWindow(object):
             status_label = "{0} | <b>Peer count</b> {1} | <b>Last Updated</b> {2}".format(block_height_string, self.status['peerCount'], datetime.now(tzlocal.get_localzone()).strftime("%H:%M:%S"))
             self.builder.get_object("MainStatusLabel").set_markup(status_label)
 
-        #Logging here for debug purposes. Sloppy Joe..
-        main_logger.debug("REFRESH STATS:" + "\r\n" +
-                          "AvailableBalanceAmountLabel: {:,.2f}".format(balances['availableBalance']/100.) + "\r\n" +
-                          "LockedBalanceAmountLabel: {:,.2f}".format(balances['lockedAmount']/100.) + "\r\n" +
-                          "Address: " + str(addresses[0])  + "\r\n" +
-                           "Status: " + "{0} | Peer count {1} | Last Updated {2}".format(block_height_string, status['peerCount'], datetime.now(tzlocal.get_localzone()).strftime("%H:%M:%S")))
+            #Logging here for debug purposes. Sloppy Joe..
+            main_logger.debug("REFRESH STATS:" + "\r\n" +
+                              "AvailableBalanceAmountLabel: {:,.2f}".format(self.balances['availableBalance']/100.) + "\r\n" +
+                              "LockedBalanceAmountLabel: {:,.2f}".format(self.balances['lockedAmount']/100.) + "\r\n" +
+                              "Address: " + str(self.addresses[0])  + "\r\n" +
+                               "Status: " + "{0} | Peer count {1} | Last Updated {2}".format(block_height_string, self.status['peerCount'], datetime.now(tzlocal.get_localzone()).strftime("%H:%M:%S")))
 
         return True
 

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -369,7 +369,6 @@ class MainWindow(object):
                 self.currentTimeout += 1
                 
             self.set_error_status()
-            return
             return False
 
         # Iterate through the blocks and extract the relevant data
@@ -393,7 +392,6 @@ class MainWindow(object):
                             break
 
                     # Append new transactions to the treeview's backing list store in the correct format
-                    if transaction['transactionHash'] not in [r[0] for r in self.transactions_list_store]:
                     if transaction['transactionHash'] not in [tx[0] for tx in self.transactions_list_store]:
                         self.transactions_list_store.append([
                             transaction['transactionHash'],

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -362,6 +362,7 @@ class MainWindow(object):
                 
             self.set_error_status()
             return
+            return False
 
         # Iterate through the blocks and extract the relevant data
         # This is reversed to show most recent transactions first
@@ -385,6 +386,7 @@ class MainWindow(object):
 
                     # Append new transactions to the treeview's backing list store in the correct format
                     if transaction['transactionHash'] not in [r[0] for r in self.transactions_list_store]:
+                    if transaction['transactionHash'] not in [tx[0] for tx in self.transactions_list_store]:
                         self.transactions_list_store.append([
                             transaction['transactionHash'],
                             # Determine the direction of the transfer (In/Out)
@@ -421,7 +423,13 @@ class MainWindow(object):
         self.builder.get_object("MainStatusLabel").set_markup(status_label)
         
         #Logging here for debug purposes. Sloppy Joe..
-        main_logger.debug("REFRESH STATS:" + "\r\n" + "AvailableBalanceAmountLabel: {:,.2f}".format(balances['availableBalance']/100.) + "\r\n" + "LockedBalanceAmountLabel: {:,.2f}".format(balances['lockedAmount']/100.) + "\r\n" + "Address: " + str(addresses[0])  + "\r\n" +  "Status: " + "{0} | Peer count {1} | Last Updated {2}".format(block_height_string, status['peerCount'], datetime.now(tzlocal.get_localzone()).strftime("%H:%M:%S")))
+        main_logger.debug("REFRESH STATS:" + "\r\n" +
+                          "AvailableBalanceAmountLabel: {:,.2f}".format(balances['availableBalance']/100.) + "\r\n" +
+                          "LockedBalanceAmountLabel: {:,.2f}".format(balances['lockedAmount']/100.) + "\r\n" +
+                          "Address: " + str(addresses[0])  + "\r\n" +
+                           "Status: " + "{0} | Peer count {1} | Last Updated {2}".format(block_height_string, status['peerCount'], datetime.now(tzlocal.get_localzone()).strftime("%H:%M:%S")))
+
+        return True
 
     def __init__(self):
         # Initialise the GTK builder and load the glade layout from the file

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -285,7 +285,7 @@ class MainWindow(object):
         :return:
         """
         self.builder.get_object("RecipientAddressEntry").set_text('')
-        self.builder.get_object("MixinSpinButton").set_value(0)
+        self.builder.get_object("MixinSpinButton").set_value(3)
         self.builder.get_object("AmountEntry").set_text('')
         self.builder.get_object("PaymentIDEntry").set_text('')
 
@@ -497,6 +497,10 @@ class MainWindow(object):
         self.builder.get_object("FeeEntry").set_text(str(float(global_variables.static_fee) / float(100)))
         
         
+
+        # Initialize the inputs within the send transaction frame
+        self.clear_send_ui()
+
         #If wallet is different than cached config wallet, Prompt if user would like to set default wallet
         with open(global_variables.wallet_config_file,) as configFile:
             tmpconfig = json.loads(configFile.read())

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -426,12 +426,9 @@ class MainWindow(object):
         # e.g. in case the daemon has accidentally forked and listed some transactions that are invalid
         if self.blocks:
             valid_transactions = [transaction['transactionHash'] for transaction in block['transactions'] for block in self.blocks]
-            rows = self.transactions_list_store.iter_children(None)
-            while rows:
-                columns = self.transactions_list_store.iter_children(rows)
-                if columns and self.transactions_list_store.get_value(columns, 0) not in valid_transactions:
-                    self.transactions_list_store.remove(columns)
-                rows = self.transactions_list_store.iter_next(rows)
+            for index, row in enumerate(self.transactions_list_store):
+                if row[0] not in valid_transactions:
+                    self.transactions_list_store.remove(row.iter)
         else:
             self.transactions_list_store.clear()
 

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -277,20 +277,6 @@ class MainWindow(object):
         self.builder.get_object("MixinSpinButton").set_value(0)
         self.builder.get_object("AmountEntry").set_text('')
 
-    def update_loop(self):
-        """
-        This method loops infinitely and refreshes the UI every 5 seconds.
-
-        Note:
-            More optimal differential method of reloading transactions
-            is required, as currently you can't really scroll through them
-            without it jumping back to the top when it clears the list.
-            Likely solution would be a hidden (or not) column with the
-            transaction hash."""
-        while True:
-            GLib.idle_add(self.refresh_values) # Refresh the values, calling the method via GLib
-            time.sleep(5) # Wait 5 seconds before doing it again
-
     def set_error_status(self):
         main_logger.error(global_variables.message_dict["FAILED_DAEMON_COMM"])
         self.builder.get_object("MainStatusLabel").set_label(global_variables.message_dict["FAILED_DAEMON_COMM"])
@@ -489,11 +475,9 @@ class MainWindow(object):
         except Exception as e:
             splash_logger.warn("Could not save config file: {}".format(e))
 
-        # Start the UI update loop in a new thread
-        self.update_thread = threading.Thread(target=self.update_loop)
-        self.update_thread.daemon = True
-        self.update_thread.start()
-        
+        # Register a function via Glib that gets called every 5 seconds to refresh the UI
+        GLib.timeout_add_seconds(5, self.refresh_values)
+
         #These tabs should not be shown, even on show all
         noteBook = self.builder.get_object("MainNotebook")
         #Remove Log tab

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -501,6 +501,9 @@ class MainWindow(object):
         # Initialize the inputs within the send transaction frame
         self.clear_send_ui()
 
+        # Show an initial status message
+        self.builder.get_object("MainStatusLabel").set_markup("<b>Loading...</b>")
+
         #If wallet is different than cached config wallet, Prompt if user would like to set default wallet
         with open(global_variables.wallet_config_file,) as configFile:
             tmpconfig = json.loads(configFile.read())

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -151,8 +151,8 @@ class MainWindow(object):
         r = global_variables.wallet_connection.request("reset")
         if not r:
             dialog = Gtk.MessageDialog(self.window, 0, Gtk.MessageType.INFO, Gtk.ButtonsType.OK, "Wallet Reset")
-            dialog.format_secondary_text(global_variables.message_dict["WALLET_RESET"])
-            main_logger.info(global_variables.message_dict["WALLET_RESET"])
+            dialog.format_secondary_text(global_variables.message_dict["SUCCESS_WALLET_RESET"])
+            main_logger.info(global_variables.message_dict["SUCCESS_WALLET_RESET"])
             dialog.run()
             dialog.destroy()
         else:

--- a/start.py
+++ b/start.py
@@ -46,7 +46,7 @@ logger.addHandler(fh)
 # logger.addHandler(ch)
 # ---
 
-logger.info("Tutle Wallet Stated")
+logger.info("Turtle Wallet Started")
 signal.signal(signal.SIGINT, signal.SIG_DFL) # Required to handle interrupts closing the program
 logger.info("Starting Splash Screen")
 splash_screen = SplashScreen() # Create a new instance of the splash screen


### PR DESCRIPTION
This PR resolves the issue where the transaction list keeps resetting back to the top on each refresh (#11 ), making the list actually usable now. Also made a few other UI related tweaks.

- Rather than clearing and repopulating the entire transaction list every refresh, append to it only if there are new transactions. This is done by storing the transaction hash as a hidden column and using it to determine if the transaction has already been added.

- Rather than running a separate thread to continuously call GLib.idle_add in order to refresh the UI, utilize GLib.timeout_add_seconds. This reduces/simplifies the code a little.

- Separate fetching wallet data from the UI refresh task. Occasionally fetching wallet data was taking longer than expected causing the UI to temporarily freeze.

- When first launched, the available and locked balances now display 0 (rather than -1) as it may be confusing to see a negative value initially. Also, the status bar displays "Loading..." (rather than just "Status") until the UI is refreshed for the first time.

- Change default mixin value to 3 rather than 0. I believe 3 is a reasonable default value and should be up to the user if they want to disable this privacy feature (by setting it to 0).